### PR TITLE
Restored lock in Start method for mailboxes dispatchers

### DIFF
--- a/src/Vlingo.Actors.Tests/Plugin/Mailbox/AgronaMPSCArrayQueue/ManyToOneConcurrentArrayQueueDispatcherTest.cs
+++ b/src/Vlingo.Actors.Tests/Plugin/Mailbox/AgronaMPSCArrayQueue/ManyToOneConcurrentArrayQueueDispatcherTest.cs
@@ -24,8 +24,9 @@ namespace Vlingo.Actors.Tests.Plugin.Mailbox.AgronaMPSCArrayQueue
             dispatcher.Start();
             var mailbox = dispatcher.Mailbox;
             var actor = new CountTakerActor();
+            
             actor.Until = Until(MailboxSize);
-            for(var i = 1; i<=MailboxSize; ++i)
+            for (var i = 1; i <= MailboxSize; ++i)
             {
                 var countParam = i;
                 Action<ICountTaker> consumer = consumerActor => consumerActor.Take(countParam);
@@ -36,15 +37,17 @@ namespace Vlingo.Actors.Tests.Plugin.Mailbox.AgronaMPSCArrayQueue
             actor.Until.Completes();
             dispatcher.Close();
 
-            const int neverReceived = MailboxSize * 2;
-            for(var count = MailboxSize + 1; count <= neverReceived; ++count)
+            const int neverReviewed = MailboxSize * 2;
+            for (var count = MailboxSize + 1; count <= neverReviewed; ++count)
             {
                 var countParam = count;
                 Action<ICountTaker> consumer = consumerActor => consumerActor.Take(countParam);
                 var message = new LocalMessage<ICountTaker>(actor, consumer, "Take(int)");
                 mailbox.Send(message);
             }
-
+            
+            Until(0).Completes();
+            
             Assert.Equal(MailboxSize, actor.Highest.Get());
         }
 

--- a/src/Vlingo.Actors/Plugin/Mailbox/AgronaMPSCArrayQueue/ManyToOneConcurrentArrayQueueDispatcher.cs
+++ b/src/Vlingo.Actors/Plugin/Mailbox/AgronaMPSCArrayQueue/ManyToOneConcurrentArrayQueueDispatcher.cs
@@ -37,7 +37,7 @@ namespace Vlingo.Actors.Plugin.Mailbox.AgronaMPSCArrayQueue
 
         public void Close() => closed.Set(true);
 
-        public bool IsClosed => closed.Get();
+        public bool IsClosed => closed.Get() || cancellationTokenSource.IsCancellationRequested;
 
         public void Execute(IMailbox mailbox)
         {
@@ -48,7 +48,7 @@ namespace Vlingo.Actors.Plugin.Mailbox.AgronaMPSCArrayQueue
 
         public void Run()
         {
-            while (!IsClosed && !cancellationTokenSource.IsCancellationRequested)
+            while (!IsClosed)
             {
                 if (!Deliver())
                 {
@@ -82,7 +82,10 @@ namespace Vlingo.Actors.Plugin.Mailbox.AgronaMPSCArrayQueue
                     return idx > 0; // we delivered at least one message
                 }
 
-                message.Deliver();
+                if (!IsClosed)
+                {
+                    message.Deliver();
+                }
             }
             return true;
         }

--- a/src/Vlingo.Actors/Plugin/Mailbox/AgronaMPSCArrayQueue/ManyToOneConcurrentArrayQueueDispatcher.cs
+++ b/src/Vlingo.Actors/Plugin/Mailbox/AgronaMPSCArrayQueue/ManyToOneConcurrentArrayQueueDispatcher.cs
@@ -48,7 +48,7 @@ namespace Vlingo.Actors.Plugin.Mailbox.AgronaMPSCArrayQueue
 
         public void Run()
         {
-            while (!IsClosed)
+            while (!IsClosed && !cancellationTokenSource.IsCancellationRequested)
             {
                 if (!Deliver())
                 {

--- a/src/Vlingo.Actors/Plugin/Mailbox/AgronaMPSCArrayQueue/ManyToOneConcurrentArrayQueueDispatcher.cs
+++ b/src/Vlingo.Actors/Plugin/Mailbox/AgronaMPSCArrayQueue/ManyToOneConcurrentArrayQueueDispatcher.cs
@@ -37,7 +37,13 @@ namespace Vlingo.Actors.Plugin.Mailbox.AgronaMPSCArrayQueue
             backoffTokenSource = CancellationTokenSource.CreateLinkedTokenSource(dispatcherTokenSource.Token);
         }
 
-        public void Close() => closed.Set(true);
+        public void Close()
+        {
+            closed.Set(true);
+            dispatcherTokenSource.Cancel();
+            dispatcherTokenSource.Dispose();
+            backoffTokenSource.Dispose();
+        }
 
         public bool IsClosed => closed.Get();
 
@@ -56,7 +62,7 @@ namespace Vlingo.Actors.Plugin.Mailbox.AgronaMPSCArrayQueue
             {
                 if (!Deliver())
                 {
-                    await backoff.Now();
+                    await backoff.Now(backoffTokenSource.Token);
                 }
             }
         }

--- a/src/Vlingo.Actors/Plugin/Mailbox/SharedRingBuffer/RingBufferDispatcher.cs
+++ b/src/Vlingo.Actors/Plugin/Mailbox/SharedRingBuffer/RingBufferDispatcher.cs
@@ -53,7 +53,7 @@ namespace Vlingo.Actors.Plugin.Mailbox.SharedRingBuffer
 
         public void Run()
         {
-            while (!closed.Get())
+            while (!closed.Get() && !cancellationTokenSource.IsCancellationRequested)
             {
                 if (!Deliver())
                 {


### PR DESCRIPTION
Restored lock in Start method for ManyToOneConcurrentArrayQueueDispatcher and RingBufferDispatcher. This is necessary because a client can start the mailbox from multiple threads.