### PR TITLE
Upgrade dependency Vlingo.Common to version 0.3.0

### DIFF
--- a/src/Vlingo.Actors/ResultCompletes.cs
+++ b/src/Vlingo.Actors/ResultCompletes.cs
@@ -104,22 +104,22 @@ namespace Vlingo.Actors
             throw new NotSupportedException();
         }
 
-        public virtual O AndThenInto<F, O>(long timeout, F failedOutcomeValue, Func<T, O> function)
+        public virtual O AndThenTo<F, O>(long timeout, F failedOutcomeValue, Func<T, O> function)
         {
             throw new NotSupportedException();
         }
 
-        public virtual O AndThenInto<F, O>(F failedOutcomeValue, Func<T, O> function)
+        public virtual O AndThenTo<F, O>(F failedOutcomeValue, Func<T, O> function)
         {
             throw new NotSupportedException();
         }
 
-        public virtual O AndThenInto<O>(long timeout, Func<T, O> function)
+        public virtual O AndThenTo<O>(long timeout, Func<T, O> function)
         {
             throw new NotSupportedException();
         }
 
-        public virtual O AndThenInto<O>(Func<T, O> function)
+        public virtual O AndThenTo<O>(Func<T, O> function)
         {
             throw new NotSupportedException();
         }

--- a/src/Vlingo.Actors/Vlingo.Actors.csproj
+++ b/src/Vlingo.Actors/Vlingo.Actors.csproj
@@ -4,7 +4,7 @@
 
     <!-- NuGet Metadata -->
     <IsPackable>true</IsPackable>
-    <PackageVersion>0.2.0</PackageVersion>
+    <PackageVersion>0.2.1</PackageVersion>
     <PackageId>Vlingo.Actors</PackageId>
     <Authors>Vlingo</Authors>
     <Description>

--- a/src/Vlingo.Actors/Vlingo.Actors.csproj
+++ b/src/Vlingo.Actors/Vlingo.Actors.csproj
@@ -22,6 +22,6 @@
     </AssemblyAttribute>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Vlingo.Common" Version="0.2.0" />
+    <PackageReference Include="Vlingo.Common" Version="0.3.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Upgrade dependency `Vlingo.Common` to version 0.3.0 because it was causing issues
of inconsistent versions in `Vlingo.Wire`. This certainly fixes a problem 
described in #34 "System.TypeLoadException: Method 'AndThenTo' does not have an implementation."
Changed implementation of  `AndThenInto` to `AndThenTo` for `ResultCompletes`.