### PR TITLE
Align naming with Java version

### DIFF
--- a/src/Vlingo.Actors/World.cs
+++ b/src/Vlingo.Actors/World.cs
@@ -124,7 +124,7 @@ namespace Vlingo.Actors
         /// </summary>
         /// <param name="name">The <c>string</c> name to assign to the new <c>World</c> instance.</param>
         /// <returns>A <c>World</c> instance.</returns>
-        public static World StartWithDefault(string name)
+        public static World StartWithDefaults(string name)
         {
             return Start(name, Configuration.Define());
         }


### PR DESCRIPTION
Just a small fix to naming `World.StartWithDefault` which lacks "s" compared to Java version. Now it has the correct name `World.StartWithDefaults`.

Noe need to release the new version